### PR TITLE
print file header values, add null termination to itoa, add hexdump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ASM = nasm
-AFLAGS = -f elf64
+AFLAGS = -f elf64 -g
 LD = ld
 SRC = src/main.asm
 OUT = main

--- a/src/hexdump.asm
+++ b/src/hexdump.asm
@@ -1,0 +1,37 @@
+;;; Hexdump.asm - x86 hexdump procedure
+;;; produces a hexdump of a given bufer in the form of AA BB CD EF
+;;; polprog 21.03.2025
+;;; rdi - pointer to buffer
+;;; rsi - length
+;;; rdx  - ptr to target buffer, needs to be at least 3*length+1
+hexdump:
+  ;; bl - nibble
+  mov rcx, rsi
+_hexdump_byte:	
+  mov al, [rdi] 		; al contains the first byte
+  shr al, 4		; place upper nibble in al
+  call nib2asc		; nibble to ascii, returns in *rdx++
+  
+  mov al, [rdi]		; load lower nibble to al and repeat
+  and al, 0x0f 		; the conversion
+  call nib2asc		; nibble to ascii, returns in *rdx++
+  
+  inc rdi			; next byte
+  mov [rdx], byte ' '	; place space
+  inc rdx
+  loop _hexdump_byte	
+
+  mov [rdx], byte 0x00 	; null terminate the string
+  ret
+
+nib2asc:	
+  add al, '0'		; convert to char 0-9
+  ;;  if al > '9', then add enough to move it up to the letters
+  cmp al, '9'		; compare
+  jle _belowten
+  add al, 7		
+_belowten:
+  ;; now al contains the character, move it to the target buffer
+  mov [rdx], al
+  inc rdx
+  ret

--- a/src/main.asm
+++ b/src/main.asm
@@ -12,6 +12,7 @@
 %include "src/output.asm"
 %include "src/structs.asm"
 %include "src/std.asm"
+%include "src/hexdump.asm"
 
 section   .bss
 ; VARIABLES ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ 
@@ -47,7 +48,7 @@ section   .rodata
 
   ; ELF HDR
   elf_banner    db  "______________________________________[ ELF_HEADER ]", 0x00
-  elf_magic     db  "Magic: ", 0x00
+  elf_magic     db  `Magic:\t\t`, 0x00
   elf_format    db  "Format (32 or 64bit): ", 0x00
   elf_endian    db  "Endian: ", 0x00
   elf_version   db  "Version: ", 0x00
@@ -55,15 +56,15 @@ section   .rodata
   elf_trgt_v    db  "Target Version: ", 0x00
   elf_filetype  db  "Type: ", 0x00 ; ET_DYN, ET_EXEC
   elf_instrset  db  "Instruction Set: ", 0x00 ; MIPS, RISCV, x86
-  elf_entry     db  "Entrypoint: ", 0x00
-  elf_phoff     db  "ProgHdr Offset: ", 0x00
-  elf_shoff     db  "SectHdr Offset: ", 0x00
-  elf_flags     db  "Flags: ", 0x00
-  elf_ehsize    db  "Sizeof ELF hdr: ", 0x00
-  elf_phentsize db  "Sizeof ProgHdr: ", 0x00
-  elf_phnum     db  "Num Of ProgHdr: ", 0x00
-  elf_shentsize db  "Sizeof SectHdr: ", 0x00
-  elf_shnum     db  "Num of SectHdr: ", 0x00
+  elf_entry     db  `Entrypoint:\t0x`, 0x00
+  elf_phoff     db  `ProgHdr Offset:\t0x`, 0x00
+  elf_shoff     db  `SectHdr Offset:\t0x`, 0x00
+  elf_flags     db  `Flags:\t\t`, 0x00
+  elf_ehsize    db  `Sizeof ELF hdr:\t0x`, 0x00
+  elf_phentsize db  `Sizeof ProgHdr:\t0x`, 0x00
+  elf_phnum     db  `Num Of ProgHdr:\t0x`, 0x00
+  elf_shentsize db  `Sizeof SectHdr:\t0x`, 0x00
+  elf_shnum     db  `Num of SectHdr:\t0x`, 0x00
   elf_shstrndx  db  "String Table Index: ", 0x00
 
   ; PROGRAM HDR

--- a/src/output.asm
+++ b/src/output.asm
@@ -3,11 +3,19 @@
 print_elfh:
   push  rbp
   mov   rbp,  rsp
-  sub   rbp,  0x00
+  sub   rsp,  0x80        ;allocate buffer for hexdump
 
   ; later call itoh and printc
   lea   rdi,  elf_magic
+  call  print
+
+  mov   rdi, [mapped_bin]
+  mov   rsi, 0x10
+  mov   rdx, rsp
+  call  hexdump
+  mov   rdi, rsp
   call  println
+
 
   lea   rdi,  elf_format
   call  println
@@ -23,7 +31,7 @@ print_elfh:
 
   lea   rdi,  elf_trgt_v
   call  println
-  
+
   lea   rdi,  elf_filetype
   call  println
 
@@ -31,30 +39,93 @@ print_elfh:
   call  println
 
   lea   rdi,  elf_entry
+  call  print
+  mov   rdi, [mapped_bin]
+  add   rdi, elf64_hdr.e_entry
+  mov   rdi, [rdi]
+  mov   rsi, rsp
+  call  itoa
+  mov   rdi, rsp
   call  println
 
   lea   rdi,  elf_phoff
+  call  print
+  mov   rdi, [mapped_bin]
+  add   rdi, elf64_hdr.e_phoff
+  mov   rdi, [rdi]
+  mov   rsi, rsp
+  call  itoa
+  mov   rdi, rsp
   call  println
 
   lea   rdi,  elf_shoff
+  call  print
+  mov   rdi, [mapped_bin]
+  add   rdi, elf64_hdr.e_shoff
+  mov   rdi, [rdi]
+  mov   rsi, rsp
+  call  itoa
+  mov   rdi, rsp
   call  println
 
   lea   rdi,  elf_flags
+  call  print
+  mov   rdi, [mapped_bin]
+  add   rdi, elf64_hdr.e_flags
+  mov   rsi, 0x4
+  mov   rdx, rsp
+  call  hexdump
+  mov   rdi, rsp
   call  println
 
   lea   rdi,  elf_ehsize
+  call  print
+  mov   rdi, [mapped_bin]
+  add   rdi, elf64_hdr.e_ehsize
+  movzx rdi, word [rdi]
+  mov   rsi, rsp
+  call  itoa
+  mov   rdi, rsp
   call  println
 
   lea   rdi,  elf_phentsize
+  call  print
+  mov   rdi, [mapped_bin]
+  add   rdi, elf64_hdr.e_phentsize
+  movzx rdi, word [rdi]
+  mov   rsi, rsp
+  call  itoa
+  mov   rdi, rsp
   call  println
 
   lea   rdi,  elf_phnum
+  call  print
+  mov   rdi, [mapped_bin]
+  add   rdi, elf64_hdr.e_phnum
+  movzx rdi, word [rdi]
+  mov   rsi, rsp
+  call itoa
+  mov   rdi, rsp
   call  println
 
   lea   rdi,  elf_shentsize
+  call  print
+  mov   rdi, [mapped_bin]
+  add   rdi, elf64_hdr.e_shentsize
+  movzx rdi, word [rdi]
+  mov   rsi, rsp
+  call  itoa
+  mov   rdi, rsp
   call  println
 
   lea   rdi,  elf_shnum
+  call  print
+  mov   rdi, [mapped_bin]
+  add   rdi, elf64_hdr.e_shnum
+  movzx rdi, word [rdi]
+  mov   rsi, rsp
+  call  itoa
+  mov   rdi, rsp
   call  println
 
   lea   rdi,  elf_shstrndx

--- a/src/std.asm
+++ b/src/std.asm
@@ -3,7 +3,7 @@
 
 ; ITOA ----------------------------------------------------------------------
 ; INT TO ASCII
-; converts a number to decimal representation in ASCII
+; converts a number in rax to decimal representation in ASCII in *rsi
 
 itoa:
   push  rbp
@@ -57,6 +57,8 @@ itoa_buf_loop:
 
   inc   r11             ; move ptr
   loop  itoa_buf_loop
+
+  mov   byte [r11], 0x00        ; null terminate string
 
   xor   rax,  rax  ; success
   mov   rsp,  rbp


### PR DESCRIPTION
This PR adds hexdump function to the code. It's now used to print the elf magic and flags.
I also added printing of some of the file header fields. 
ITOA now null terminates the string, r11 now points to the NUL character.
Added -g option to Makefile to aid debugging